### PR TITLE
Threadsafe Avro

### DIFF
--- a/modules/avro-server/src/main/scala/trace4cats/avro/server/AvroServer.scala
+++ b/modules/avro-server/src/main/scala/trace4cats/avro/server/AvroServer.scala
@@ -1,19 +1,15 @@
 package trace4cats.avro.server
 
-import cats.effect.kernel.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource}
 import cats.syntax.applicativeError._
-import cats.syntax.either._
-import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
+import cats.{Applicative, ApplicativeThrow}
 import com.comcast.ip4s.Port
 import fs2.io.net.Network
 import fs2.{Chunk, Pipe, Pull, Stream}
-import org.apache.avro.Schema
-import org.apache.avro.generic.GenericDatumReader
-import org.apache.avro.io.DecoderFactory
 import org.typelevel.log4cats.Logger
-import trace4cats.avro.{agentPort, AvroInstances}
+import trace4cats.avro.{agentPort, CompletedSpanDecoder}
 import trace4cats.model.CompletedSpan
 
 object AvroServer {
@@ -36,26 +32,29 @@ object AvroServer {
       go((0, 0), List.empty, bytes).stream
     }
 
-  private def decode[F[_]: Sync: Logger](schema: Schema)(bytes: Chunk[Byte]): F[Option[CompletedSpan]] =
-    Sync[F]
-      .delay {
-        val reader = new GenericDatumReader[Any](schema)
-        val decoder = DecoderFactory.get.binaryDecoder(bytes.toArray, null)
-        val record = reader.read(null, decoder)
+  private def decodeOption[F[_]: ApplicativeThrow: Logger](
+    decoder: CompletedSpanDecoder[F]
+  ): Chunk[Byte] => F[Option[CompletedSpan]] =
+    bytes =>
+      decoder
+        .decode(bytes.toArray)
+        .map[Option[CompletedSpan]](Some(_))
+        .handleErrorWith(th => Logger[F].warn(th)("Failed to decode span batch").as(Option.empty[CompletedSpan]))
 
-        record
-      }
-      .flatMap[Option[CompletedSpan]] { record =>
-        Sync[F].fromEither(AvroInstances.completedSpanCodec.decode(record, schema).bimap(_.throwable, Some(_)))
-      }
-      .handleErrorWith(th => Logger[F].warn(th)("Failed to decode span batch").as(Option.empty[CompletedSpan]))
-
+  /** Creates a TCP server listens for traces from an Avro exporter.
+    *
+    * @param decoder
+    *   an optional instance of [[CompletedSpanDecoder]]. This should be used when multiple Avro exporters are used in a
+    *   single instance so that decoding remains thread safe
+    */
   def tcp[F[_]: Async: Logger](
     sink: Pipe[F, CompletedSpan, Unit],
     port: Int = agentPort,
+    decoder: Option[CompletedSpanDecoder[F]] = None
   ): Resource[F, Stream[F, Unit]] =
     for {
-      avroSchema <- Resource.eval(AvroInstances.completedSpanSchema[F])
+      dec <- Resource.eval(decoder.fold(CompletedSpanDecoder[F])(Applicative[F].pure(_)))
+      decode = decodeOption(dec)
       socketGroup <- Network[F].socketGroup()
       port <- Resource.eval(Port.fromInt(port).liftTo[F](new IllegalArgumentException(s"invalid port $port")))
     } yield socketGroup
@@ -63,24 +62,32 @@ object AvroServer {
       .map { socket =>
         socket.reads
           .through(buffer[F])
-          .evalMap(decode[F](avroSchema))
+          .evalMap(decode)
           .unNone
           .through(sink)
       }
       .parJoin(100)
 
+  /** Creates a UDP server listens for traces from an Avro exporter.
+    *
+    * @param decoder
+    *   an optional instance of [[CompletedSpanDecoder]]. This should be used when multiple Avro exporters are used in a
+    *   single instance so that decoding remains thread safe
+    */
   def udp[F[_]: Async: Logger](
     sink: Pipe[F, CompletedSpan, Unit],
     port: Int = agentPort,
+    decoder: Option[CompletedSpanDecoder[F]] = None
   ): Resource[F, Stream[F, Unit]] =
     for {
-      avroSchema <- Resource.eval(AvroInstances.completedSpanSchema[F])
+      dec <- Resource.eval(decoder.fold(CompletedSpanDecoder[F])(Applicative[F].pure(_)))
+      decode = decodeOption(dec)
       port <- Resource.eval(Port.fromInt(port).liftTo[F](new IllegalArgumentException(s"invalid port $port")))
       socketGroup <- Network[F].datagramSocketGroup()
       socket <- socketGroup.openDatagramSocket(port = Some(port))
     } yield socket.reads
       .map(_.bytes)
-      .evalMap(decode[F](avroSchema))
+      .evalMap(decode)
       .unNone
       .through(sink)
 }

--- a/modules/avro-test/src/test/scala/trace4cats/avro/test/AvroServerSpec.scala
+++ b/modules/avro-test/src/test/scala/trace4cats/avro/test/AvroServerSpec.scala
@@ -27,7 +27,7 @@ class AvroServerSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks wit
     PropertyCheckConfiguration(minSuccessful = 1, maxDiscardedFactor = 50.0)
 
   implicit val nBatchesArbitrary: Arbitrary[(Int, List[Batch[Chunk]])] = Arbitrary(for {
-    n <- Gen.choose(2, 4)
+    n <- Gen.choose(10, 20)
     list <- Gen.listOfN(n, batchArb.arbitrary)
   } yield (n, list))
 

--- a/modules/avro/src/main/scala/trace4cats/avro/CompletedSpanDecoder.scala
+++ b/modules/avro/src/main/scala/trace4cats/avro/CompletedSpanDecoder.scala
@@ -1,0 +1,35 @@
+package trace4cats.avro
+
+import cats.effect.kernel.Sync
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.io.{BinaryDecoder, DecoderFactory}
+import trace4cats.model.CompletedSpan
+
+trait CompletedSpanDecoder[F[_]] {
+  def decode(bytes: Array[Byte]): F[CompletedSpan]
+}
+
+object CompletedSpanDecoder {
+  // Avro decoding isn't thread safe. This ensures that there is exactly one avro decoder for each thread
+  def apply[F[_]: Sync]: F[CompletedSpanDecoder[F]] = for {
+    schema <- AvroInstances.completedSpanSchema[F]
+    factory <- Sync[F].delay(DecoderFactory.get())
+    decoder <- Sync[F].delay(new ThreadLocal[BinaryDecoder])
+    reader <- Sync[F].delay(ThreadLocal.withInitial(() => new GenericDatumReader[Any](schema)))
+  } yield new CompletedSpanDecoder[F] {
+    override def decode(bytes: Array[Byte]): F[CompletedSpan] =
+      Sync[F]
+        .delay {
+          val decoderInstance = factory.binaryDecoder(bytes, decoder.get())
+
+          val r = reader.get()
+          r.read(null, decoderInstance)
+        }
+        .flatMap { record =>
+          Sync[F].fromEither(AvroInstances.completedSpanCodec.decode(record, schema).leftMap(_.throwable))
+        }
+  }
+}

--- a/modules/avro/src/main/scala/trace4cats/avro/CompletedSpanEncoder.scala
+++ b/modules/avro/src/main/scala/trace4cats/avro/CompletedSpanEncoder.scala
@@ -1,0 +1,44 @@
+package trace4cats.avro
+
+import java.io.ByteArrayOutputStream
+
+import cats.effect.kernel.{Resource, Sync}
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import org.apache.avro.generic.GenericDatumWriter
+import org.apache.avro.io.{BinaryEncoder, EncoderFactory}
+import trace4cats.model.CompletedSpan
+
+trait CompletedSpanEncoder[F[_]] {
+  def encode(span: CompletedSpan): F[Array[Byte]]
+}
+
+object CompletedSpanEncoder {
+  // Avro encoding isn't thread safe. This ensures that there is exactly one avro decoder for each thread
+  def apply[F[_]: Sync]: F[CompletedSpanEncoder[F]] = {
+    for {
+      schema <- AvroInstances.completedSpanSchema[F]
+      factory <- Sync[F].delay(EncoderFactory.get())
+      encoder <- Sync[F].delay(new ThreadLocal[BinaryEncoder])
+      writer <- Sync[F].delay(ThreadLocal.withInitial(() => new GenericDatumWriter[Any](schema)))
+    } yield new CompletedSpanEncoder[F] {
+      override def encode(span: CompletedSpan): F[Array[Byte]] = Resource
+        .fromAutoCloseable(Sync[F].delay(new ByteArrayOutputStream))
+        .use { out =>
+          Sync[F]
+            .fromEither(AvroInstances.completedSpanCodec.encode(span).leftMap(_.throwable))
+            .flatMap { record =>
+              Sync[F].delay {
+                val encoderInstance = factory.directBinaryEncoder(out, encoder.get())
+                encoder.set(encoderInstance)
+
+                val w = writer.get()
+                w.write(record, encoderInstance)
+                out.toByteArray
+              }
+            }
+        }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.8"
     val scala3 = "3.1.2"
 
-    val trace4cats = "0.13.1+67-a7d9b849"
+    val trace4cats = "0.13.1+114-c5a4b269"
 
     val fs2 = "3.2.10"
     val log4cats = "2.4.0"


### PR DESCRIPTION
Avro encoding/decoding isn't threadsafe. This creates an encoder and decoder
that uses `ThreadLocal` for storing the underlying Avro encoder/decoders.

Assumes that most of the time people won't have multiple Avro exporters so
defaults to constructing the encoder/decoder for them. The agent/collector
should make sure there is only one instance of the encoder/decoder however.