### PR TITLE
Upgrade vulcan dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,50 +28,43 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
+          cache: sbt
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check formatting
-        run: sbt ++${{ matrix.scala }} scalafmtCheckAll scalafmtSbtCheck
+        run: sbt '++ ${{ matrix.scala }}' scalafmtCheckAll scalafmtSbtCheck
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Compress target directories
         run: tar cf targets.tar modules/avro-test/target target modules/avro-exporter/target modules/avro/target modules/avro-server/target project/target
 
       - name: Upload target directories
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
           path: targets.tar
@@ -88,38 +81,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
+          cache: sbt
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.8)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-2.13.8-${{ matrix.java }}
 
@@ -129,7 +115,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.12.16)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-2.12.16-${{ matrix.java }}
 
@@ -139,7 +125,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3.1.3)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-3.1.3-${{ matrix.java }}
 
@@ -159,4 +145,4 @@ jobs:
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt ++${{ matrix.scala }} ciReleaseSonatype
+        run: sbt ciReleaseSonatype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 2.12.16, 3.1.3]
+        scala: [2.13.8, 2.12.16, 3.3.3]
         java: [temurin@8, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -124,12 +124,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3)
+      - name: Download target directories (3.3.3)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-3.1.3-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.3-${{ matrix.java }}
 
-      - name: Inflate target directories (3.1.3)
+      - name: Inflate target directories (3.3.3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -17,6 +17,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Delete artifacts
+        shell: bash {0}
         run: |
           # Customize those three lines with your repository and credentials:
           REPO=${GITHUB_API_URL}/repos/${{ github.repository }}
@@ -25,7 +26,7 @@ jobs:
           ghapi() { curl --silent --location --user _:$GITHUB_TOKEN "$@"; }
 
           # A temporary file which receives HTTP response headers.
-          TMPFILE=/tmp/tmp.$$
+          TMPFILE=$(mktemp)
 
           # An associative array, key: artifact name, value: number of artifacts of that name.
           declare -A ARTCOUNT

--- a/modules/avro/src/test/scala-2.13/trace4cats/avro/AvroGenericInstances.scala
+++ b/modules/avro/src/test/scala-2.13/trace4cats/avro/AvroGenericInstances.scala
@@ -34,11 +34,7 @@ object AvroGenericInstances {
   implicit val spanContextCodec: Codec[SpanContext] = Codec.derive
 
   implicit def evalCodec[A: Codec]: Codec[Eval[A]] =
-    Codec.instance(
-      Codec[A].schema,
-      a => Codec[A].encode(a.value),
-      (obj, schema) => Codec[A].decode(obj, schema).map(Eval.later(_))
-    )
+    Codec[A].imap(Eval.later(_))(_.value)
 
   implicit val traceValueCodec: Codec[AttributeValue] = Codec.derive[AttributeValue]
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.16"
     val scala213 = "2.13.8"
-    val scala3 = "3.1.3"
+    val scala3 = "3.3.3"
 
     val trace4cats = "0.14.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val fs2 = "3.2.14"
     val log4cats = "2.4.0"
     val logback = "1.2.13"
-    val vulcan = "1.8.3"
+    val vulcan = "1.11.1"
     val slf4j = "1.7.36"
 
     val kindProjector = "0.13.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"         % "2.5.2")
 addSbtPlugin("org.typelevel"  % "sbt-tpolecat"         % "0.5.2")
-addSbtPlugin("com.codecommit" % "sbt-github-actions"   % "0.14.2")
+addSbtPlugin("com.github.sbt" % "sbt-github-actions"   % "0.24.0")
 addSbtPlugin("io.shiftleft"   % "sbt-ci-release-early" % "2.0.46")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"           % "5.0.1")


### PR DESCRIPTION
The current version of vulcan uses a version of avro which has [a vulnerability](https://nvd.nist.gov/vuln/detail/cve-2023-39410). This upgrade bumps it to a fixed version.

There appears to have been a fix in the vulcan generic codec generation such that it is now correctly recognising default parameters. One test in this codebase has been updated to reflect this.

The only other change is removing a couple of usages of a deprecated method (`Codec.instance`).